### PR TITLE
Bugfix for IE7 / IE8

### DIFF
--- a/src/jquery.counter.js
+++ b/src/jquery.counter.js
@@ -52,7 +52,7 @@
                 while (digits.length < part.padding) {
                     digits = '0' + digits;
                 }
-                $.each(digits, function(j, digit) {
+                $.each(digits.split(''), function(j, digit) {
                     animate(e, i, j, digit)
                 });
                 i--;
@@ -60,7 +60,7 @@
         };
 
         var animate = function(e, ipart, idigit, digit) {
-            var edigit = $($(e.find('> span.part').get(ipart)).find('> span.digit').get(idigit));
+            var edigit = $($(e.children().get(ipart)).find('span.digit').get(idigit));
             edigit.attr('class', 'digit digit' + digit +  ' digit' + edigit.text() + digit).text(digit);
         };
 


### PR DESCRIPTION
By default, the counter doesn't show any numbers in frontend while using IE7 or IE8.

Here is the original line from jquery.counter.js where this bug appears:

LINE 55: $.each(digits, function(j, digit) {

replace with: $.each(digits.split(''), function(j, digit) {

Then replace the following line 63:

var edigit = $($(e.find('> span.part').get(ipart)).find('> span.digit').get(idigit));

with:

var edigit = $($(e.children().get(ipart)).find('.digit').get(idigit));

because IE7 can't handle this css parent > feature i guess.
