### PR TITLE
Digits are not displayed in IE7.

### DIFF
--- a/src/jquery.counter-analog.css
+++ b/src/jquery.counter-analog.css
@@ -20,8 +20,14 @@
     vertical-align: middle;
     text-align: center;
     direction: ltr;
-    text-indent: -9000px;
     margin: 0;
+}
+
+.counter-analog2 span.part span.digit span.inner{
+  width: 0px;
+  height: 0px;
+  overflow: hidden;
+  display: block;
 }
 
 .counter-analog span.part span.digit {

--- a/src/jquery.counter-analog2.css
+++ b/src/jquery.counter-analog2.css
@@ -20,8 +20,14 @@
     vertical-align: middle;
     text-align: center;
     direction: ltr;
-    text-indent: -9000px;
     margin: 0;
+}
+
+.counter-analog2 span.part span.digit span.inner{
+  width: 0px;
+  height: 0px;
+  overflow: hidden;
+  display: block;
 }
 
 .counter-analog2 span.part span.digit {

--- a/src/jquery.counter.js
+++ b/src/jquery.counter.js
@@ -65,7 +65,8 @@
 
         var animate = function(e, ipart, idigit, digit) {
             var edigit = $($(e.children('span.part').get(ipart)).find('span.digit').get(idigit));
-            edigit.attr('class', 'digit digit' + digit +  ' digit' + edigit.text() + digit).text(digit);
+            edigit.attr('class', 'digit digit' + digit +  ' digit' + edigit.text() + digit);
+            edigit.html($('<span>').addClass('inner').text(digit));
         };
 
         return this.each(function() {


### PR DESCRIPTION
Due to the `text-indent: -9000px;` attribute, IE7 indents the span's background (aka the digit image) all the way left as well as the inner text (Check your demo page in IE7). I converted the script to use the "Dwyer Method" of hiding the digit text as oultlined here: http://www.mezzoblue.com/tests/revised-image-replacement/
